### PR TITLE
Exemplo funcional de Todo com expo-model-kit

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,73 +1,274 @@
-import { useEvent } from 'expo';
-import ExpoModelKit, { ExpoModelKitView } from 'expo-model-kit';
-import { Button, SafeAreaView, ScrollView, Text, View } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, Text, View, Button, ScrollView, TextInput, SafeAreaView } from 'react-native';
+import 'reflect-metadata';
+
+import { Model, Field, initialize, insert, findAll } from 'expo-model-kit';
+
+@Model({ tableName: 'tasks' })
+class Task {
+  @Field({ primaryKey: true, autoIncrement: true, type: 'INTEGER' })
+  id?: number;
+  
+  @Field()
+  title: string;
+  
+  @Field({ nullable: true })
+  description?: string;
+  
+  @Field({ type: 'INTEGER', defaultValue: 0 })
+  completed: number;
+  
+  @Field()
+  createdAt: string;
+  
+  constructor(title: string, description?: string) {
+    this.title = title;
+    this.description = description;
+    this.completed = 0;
+    this.createdAt = new Date().toISOString();
+  }
+}
 
 export default function App() {
-  const onChangePayload = useEvent(ExpoModelKit, 'onChange');
+  const [isLoading, setIsLoading] = useState(true);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [newTaskTitle, setNewTaskTitle] = useState('');
+  const [newTaskDescription, setNewTaskDescription] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const initializeDb = async () => {
+      try {
+        await initialize();
+        console.log('Banco de dados inicializado com sucesso');
+        
+        await loadTasks();
+      } catch (err) {
+        console.error('Erro ao inicializar banco de dados:', err);
+        setError('Falha ao inicializar o banco de dados');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    initializeDb();
+  }, []);
+
+  const loadTasks = async () => {
+    try {
+      const loadedTasks = await findAll<Task>(Task);
+      setTasks(loadedTasks);
+    } catch (err) {
+      console.error('Erro ao carregar tarefas:', err);
+      setError('Falha ao carregar as tarefas');
+    }
+  };
+
+  const addTask = async () => {
+    if (!newTaskTitle.trim()) {
+      setError('Título da tarefa não pode ser vazio');
+      return;
+    }
+
+    try {
+      setError(null);
+      
+      const taskId = await insert(Task, {
+        title: newTaskTitle,
+        description: newTaskDescription.trim() || undefined,
+        completed: 0,
+        createdAt: new Date().toISOString()
+      });
+      
+      console.log(`Tarefa inserida com ID: ${taskId}`);
+      
+      setNewTaskTitle('');
+      setNewTaskDescription('');
+      
+      await loadTasks();
+    } catch (err) {
+      console.error('Erro ao inserir tarefa:', err);
+      setError('Falha ao adicionar a tarefa');
+    }
+  };
+
+  const renderTaskItem = (task: Task) => {
+    return (
+      <View key={task.id} style={styles.taskItem}>
+        <View style={styles.taskContent}>
+          <Text style={[
+            styles.taskTitle,
+            task.completed === 1 && styles.completedTask
+          ]}>
+            {task.title}
+          </Text>
+          {task.description ? (
+            <Text style={styles.taskDescription}>{task.description}</Text>
+          ) : null}
+          <Text style={styles.taskDate}>
+            Criado em: {new Date(task.createdAt).toLocaleDateString()}
+          </Text>
+        </View>
+      </View>
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <View style={styles.centerContainer}>
+        <Text>Inicializando banco de dados...</Text>
+      </View>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container}>
-      <ScrollView style={styles.container}>
-        <Text style={styles.header}>Module API Example</Text>
-        <Group name="Constants">
-          <Text>{ExpoModelKit.PI}</Text>
-        </Group>
-        <Group name="Functions">
-          <Text>{ExpoModelKit.hello()}</Text>
-        </Group>
-        <Group name="Async functions">
-          <Button
-            title="Set value"
-            onPress={async () => {
-              await ExpoModelKit.setValueAsync('Hello from JS!');
-            }}
-          />
-        </Group>
-        <Group name="Events">
-          <Text>{onChangePayload?.value}</Text>
-        </Group>
-        <Group name="Views">
-          <ExpoModelKitView
-            url="https://www.example.com"
-            onLoad={({ nativeEvent: { url } }) => console.log(`Loaded: ${url}`)}
-            style={styles.view}
-          />
-        </Group>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>Lista de Tarefas</Text>
+        <Text style={styles.headerSubtitle}>
+          Usando @rapaduralabs/expo-model-kit
+        </Text>
+      </View>
+
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.input}
+          placeholder="Título da tarefa"
+          value={newTaskTitle}
+          onChangeText={setNewTaskTitle}
+        />
+        <TextInput
+          style={[styles.input, styles.textArea]}
+          placeholder="Descrição (opcional)"
+          value={newTaskDescription}
+          onChangeText={setNewTaskDescription}
+          multiline
+          numberOfLines={3}
+        />
+        <Button title="Adicionar Tarefa" onPress={addTask} />
+      </View>
+
+      {error ? (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      ) : null}
+
+      <ScrollView style={styles.taskList}>
+        {tasks.length === 0 ? (
+          <Text style={styles.emptyListMessage}>
+            Nenhuma tarefa encontrada. Adicione sua primeira tarefa!
+          </Text>
+        ) : (
+          tasks.map(renderTaskItem)
+        )}
       </ScrollView>
     </SafeAreaView>
   );
 }
 
-function Group(props: { name: string; children: React.ReactNode }) {
-  return (
-    <View style={styles.group}>
-      <Text style={styles.groupHeader}>{props.name}</Text>
-      {props.children}
-    </View>
-  );
-}
-
-const styles = {
-  header: {
-    fontSize: 30,
-    margin: 20,
-  },
-  groupHeader: {
-    fontSize: 20,
-    marginBottom: 20,
-  },
-  group: {
-    margin: 20,
-    backgroundColor: '#fff',
-    borderRadius: 10,
-    padding: 20,
-  },
+const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#eee',
+    backgroundColor: '#f5f5f5',
   },
-  view: {
+  centerContainer: {
     flex: 1,
-    height: 200,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#f5f5f5',
   },
-};
+  header: {
+    backgroundColor: '#2196F3',
+    padding: 20,
+    paddingTop: 40,
+  },
+  headerTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  headerSubtitle: {
+    fontSize: 14,
+    color: 'rgba(255, 255, 255, 0.8)',
+    marginTop: 4,
+  },
+  inputContainer: {
+    backgroundColor: 'white',
+    padding: 16,
+    borderRadius: 8,
+    margin: 16,
+    elevation: 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 3,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 4,
+    padding: 8,
+    marginBottom: 12,
+  },
+  textArea: {
+    height: 80,
+    textAlignVertical: 'top',
+  },
+  taskList: {
+    flex: 1,
+    paddingHorizontal: 16,
+  },
+  taskItem: {
+    backgroundColor: 'white',
+    borderRadius: 8,
+    padding: 16,
+    marginBottom: 12,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    elevation: 1,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+  },
+  taskContent: {
+    flex: 1,
+    marginRight: 12,
+  },
+  taskTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginBottom: 4,
+  },
+  completedTask: {
+    textDecorationLine: 'line-through',
+    color: '#999',
+  },
+  taskDescription: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 8,
+  },
+  taskDate: {
+    fontSize: 12,
+    color: '#999',
+  },
+  errorContainer: {
+    backgroundColor: '#ffebee',
+    padding: 12,
+    borderRadius: 4,
+    marginHorizontal: 16,
+    marginBottom: 16,
+  },
+  errorText: {
+    color: '#c62828',
+  },
+  emptyListMessage: {
+    textAlign: 'center',
+    marginTop: 40,
+    color: '#666',
+    fontSize: 16,
+  },
+});

--- a/example/app.json
+++ b/example/app.json
@@ -26,6 +26,24 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      [
+        "expo-sqlite",
+        {
+          "enableFTS": true,
+          "useSQLCipher": true,
+          "android": {
+            "enableFTS": false,
+            "useSQLCipher": false
+          },
+          "ios": {
+            "customBuildFlags": [
+              "-DSQLITE_ENABLE_DBSTAT_VTAB=1 -DSQLITE_ENABLE_SNAPSHOT=1"
+            ]
+          }
+        }
+      ]
+    ]
   }
 }

--- a/example/index.ts
+++ b/example/index.ts
@@ -2,7 +2,4 @@ import { registerRootComponent } from 'expo';
 
 import App from './App';
 
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
 registerRootComponent(App);

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -2,9 +2,17 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "useDefineForClassFields": true,
+    "experimentalDecorators": true,
     "paths": {
-      "expo-model-kit": ["../src/index"],
-      "expo-model-kit/*": ["../src/*"]
+      "expo-model-kit": [
+        "../src/index"
+      ],
+      "expo-model-kit/*": [
+        "../src/*"
+      ]
     }
   }
 }

--- a/src/decorators/Field.ts
+++ b/src/decorators/Field.ts
@@ -1,0 +1,7 @@
+export function Field(type: string): PropertyDecorator {
+  return (target, propertyKey) => {
+    const fields = Reflect.getMetadata('fields', target.constructor) || [];
+    fields.push({ name: propertyKey as string, type });
+    Reflect.defineMetadata('fields', fields, target.constructor);
+  };
+}

--- a/src/decorators/Model.ts
+++ b/src/decorators/Model.ts
@@ -1,0 +1,7 @@
+import 'reflect-metadata';
+
+export function Model(): ClassDecorator {
+  return (target) => {
+    Reflect.defineMetadata('model', true, target);
+  };
+}


### PR DESCRIPTION
Este PR adiciona um exemplo funcional de lista de tarefas usando o @rapaduralabs/expo-model-kit com persistência local SQLite e melhorias na UI.